### PR TITLE
32 add slug to businesses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,4 +25,8 @@ class ApplicationController < ActionController::Base
     session[:forwarding_url] = request.url if request.get?
   end
 
+  def render_404
+    raise ActionController::RoutingError.new("Not Found")
+  end
+
 end

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -1,10 +1,11 @@
 class BusinessesController < ApplicationController
+
   def new
     @business = Business.new
   end
 
   def show
-    @business = Business.find_by(slug: params[:slug])
+    @business = Business.find_by(slug: params[:slug]) or render_404
   end
 
   def create

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -4,14 +4,14 @@ class BusinessesController < ApplicationController
   end
 
   def show
-    @business = Business.find(params[:id])
+    @business = Business.find_by(slug: params[:slug])
   end
 
   def create
     business = Business.new(business_params)
     if business.save
       flash[:success] = "Successfully registered business"
-      redirect_to company_dashboard_path(id: business.id)
+      redirect_to company_dashboard_path(slug: business.slug)
     else
       flash[:errors] = "Invalid paremeters"
       render :new

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -1,3 +1,13 @@
 class Business < ActiveRecord::Base
   belongs_to :user
+
+  validates :slug, uniqueness: true, presence: true
+
+  before_validation :generate_slug
+
+  private
+
+  def generate_slug
+    self.slug = name.parameterize
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
   resources :jobs, only: [:new, :show, :index]
   get "/jobs", to: "jobs#index"
 
-  get "/:business", as: :business, to: "businesses#show"
   resources :businesses, only: [:new, :create]
   get "/company-dashboard", to: "businesses#show"
 
@@ -34,4 +33,5 @@ Rails.application.routes.draw do
     resources :categories
   end
 
+  get "/:slug", as: :business, to: "businesses#show"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources :jobs, only: [:new, :show, :index]
   get "/jobs", to: "jobs#index"
 
+  get "/:business", as: :business, to: "businesses#show"
   resources :businesses, only: [:new, :create]
   get "/company-dashboard", to: "businesses#show"
 

--- a/spec/features/user_visits_a_business_spec.rb
+++ b/spec/features/user_visits_a_business_spec.rb
@@ -17,7 +17,8 @@ RSpec.feature "User visits a business" do
     scenario "and follows the slug path to get there" do
       log_in
       visit "/pivotal-labs"
-      expect(current_path).to eq(businesses_show_path)
+
+      expect(current_path).to eq("/pivotal-labs")
       expect(page).to have_content("Pivotal Labs")
       expect(page).to have_content("Business Consultancy")
     end

--- a/spec/features/user_visits_a_business_spec.rb
+++ b/spec/features/user_visits_a_business_spec.rb
@@ -23,4 +23,14 @@ RSpec.feature "User visits a business" do
       expect(page).to have_content("Business Consultancy")
     end
   end
+
+  context "but types in the wrong slug" do
+    before(:each) do
+      @user = create(:user)
+      @business = create(:business, user_id: @user.id)
+    end
+    scenario "and is redirected to a 404 page" do
+      expect { visit "/pivotallabs" }.to raise_error(ActionController::RoutingError)
+    end
+  end
 end

--- a/spec/features/user_visits_a_business_spec.rb
+++ b/spec/features/user_visits_a_business_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+def log_in
+  visit "/login"
+  fill_in("session[email]", with: @user.email)
+  fill_in("session[password]", with: @user.password)
+  click_button "Login"
+end
+
+RSpec.feature "User visits a business" do
+  context "after logging in" do
+    before(:each) do
+      @user = create(:user)
+      @user2 = create(:user, full_name: "Matt Hecker", email: "matt@example.com", password: "password")
+      @business = create(:business, user_id: @user2.id)
+    end
+    scenario "and follows the slug path to get there" do
+      log_in
+      visit "/pivotal-labs"
+      expect(current_path).to eq(businesses_show_path)
+      expect(page).to have_content("Pivotal Labs")
+      expect(page).to have_content("Business Consultancy")
+    end
+  end
+end


### PR DESCRIPTION
The main premise here is that users should be able to go to a businesses show page via a slug instead of by typing in a business id.

/pivotal-labs 

instead of

/businesses/1

Also implemented a test so that if users enter a different entry that is not a business it will raise a 404 error.
