### PR TITLE
64 user signs up closes #64

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,22 @@
 class UsersController < ApplicationController
   # before_filter :authorize
 
+  def new
+    @user = User.new
+  end
+
+  def create
+    user = User.new(user_params)
+    if user.save
+      session[:user_id] = user.id
+      flash[:notice] = "Account created"
+      redirect_back_or profile_path
+    else
+      flash[:errors] = "Account not created"
+      render :new
+    end
+  end
+
   def show
     @user = current_user
     @jobs = Job.all
@@ -11,6 +27,11 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def user_params
+    params.require(:user).permit(:full_name, :display_name, :email,
+      :password)
+  end
 
   def authorize
     unless current_user

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,7 @@
+<%= form_for @user do |f| %>
+  <%= f.text_field :full_name, placeholder: "Full Name" %>
+  <%= f.text_field :display_name, placeholder: "Display Name" %>
+  <%= f.text_field :email, placeholder: "Email" %>
+  <%= f.password_field :password, placeholder: "Password" %>
+  <%= f.submit "Create Account" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   root 'home#index'
 
   get "/profile", to: "users#show"
+  get "/signup", to: "users#new"
+  resources :users, only: [:create, :edit, :update]
   resources :jobs, only: [:create, :new, :show, :index]
   get "/jobs", to: "jobs#index"
 

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "User signs up" do
+  context "an unauthenticated user" do
+    scenario "signs up and is saved" do
+      visit signup_path
+      fill_in("full_name", with: "Matt H")
+      fill_in("Email", with: "matt@example.com")
+      fill_in("Display Name", with: "Matt")
+      click_on "Create Account"
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content("Matt H")
+      expect(page).to have_content("matt@example.com")
+    end
+  end
+end

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -4,9 +4,11 @@ RSpec.feature "User signs up" do
   context "an unauthenticated user" do
     scenario "signs up and is saved" do
       visit signup_path
-      fill_in("full_name", with: "Matt H")
-      fill_in("Email", with: "matt@example.com")
-      fill_in("Display Name", with: "Matt")
+      save_and_open_page
+      fill_in("user[full_name]", with: "Matt H")
+      fill_in("user[email]", with: "matt@example.com")
+      fill_in("user[display_name]", with: "Matt")
+      fill_in("user[password]", with: "password")
       click_on "Create Account"
 
       expect(current_path).to eq(profile_path)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  config.backtrace_exclusion_patterns << %r{/gems/}
 
   config.use_transactional_fixtures = true
 


### PR DESCRIPTION
We noticed that a user could not create a new account (which is an important feature for someone looking to post jobs but doesnt have a github account).

This PR runs through and implements cursory functionality for creating a new user.
