### PR TITLE
69 create resume form connects to #69 connects to #70 closes #8

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,14 @@
 class ApplicationController < ActionController::Base
+  before_action :current_client
   protect_from_forgery with: :exception
   helper_method :current_user
 
+  def current_client
+    client ||= Octokit::Client.new \
+      client_id: ENV["github_key"],
+      client_secret: ENV["github_secret"]
+    client
+  end
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]

--- a/app/controllers/resumes_controller.rb
+++ b/app/controllers/resumes_controller.rb
@@ -1,6 +1,38 @@
 class ResumesController < ApplicationController
   def new
     @resume = Resume.new
-    @repositories = current_client.reposoitories(current_user.nickname).map { |repo| repo[:name] }
+    handler ||= RepositoryHandler.new(current_client, current_user)
+    if handler.populate_repositories
+      @repositories = Repository.all
+    else
+      flash[:errors] = "Couldn't hear back from github"
+      redirect_to profile_path
+    end
+  end
+
+  def create
+    resume = current_user.resumes.new(resume_params)
+    resume_params[:repository_ids].each do |repository_id|
+      ResumeRepository.find_or_create_by(resume_id: resume.id, repository_id:
+        repository_id)
+    end
+    if resume.save
+      flash[:success] = "Resume created"
+      redirect_to profile_path
+    else
+      flash[:errors] = "Resume not created"
+      render :new
+    end
+  end
+
+  def show
+    @resume = Resume.find(params[:id])
+    @repositories = @resume.repositories
+  end
+
+  private
+
+  def resume_params
+    params.require(:resume).permit(:title, repository_ids: [])
   end
 end

--- a/app/controllers/resumes_controller.rb
+++ b/app/controllers/resumes_controller.rb
@@ -1,0 +1,6 @@
+class ResumesController < ApplicationController
+  def new
+    @resume = Resume.new
+    @repositories = current_client.reposoitories(current_user.nickname).map { |repo| repo[:name] }
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
       @user = current_user
       @jobs = Job.all.sample(4)
       @watchlist = @user.watched
+      @resumes = @user.resumes
     end
   end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,0 +1,4 @@
+class Repository < ActiveRecord::Base
+  has_many :resume_repositories
+  has_many :resumes, through: :resume_repositories
+end

--- a/app/models/repository_handler.rb
+++ b/app/models/repository_handler.rb
@@ -1,0 +1,15 @@
+class RepositoryHandler
+  attr_reader :client, :user
+
+  def initialize(current_client, current_user)
+    @client = current_client
+    @user   = current_user
+  end
+
+  def populate_repositories
+    client.repositories(user.nickname).each do |repo|
+      Repository.create(full_name: repo[:full_name], name: repo[:name])
+    end
+    true
+  end
+end

--- a/app/models/resume.rb
+++ b/app/models/resume.rb
@@ -1,0 +1,5 @@
+class Resume < ActiveRecord::Base
+  has_many :resume_repositories
+  has_many :repositories, through: :resume_repositories
+  belongs_to :user
+end

--- a/app/models/resume_repository.rb
+++ b/app/models/resume_repository.rb
@@ -1,0 +1,4 @@
+class ResumeRepository < ActiveRecord::Base
+  belongs_to :resume
+  belongs_to :repository
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ActiveRecord::Base
   has_many :tags, as: :taggable
   has_many :tag_names, through: :tags
   has_many :watched_jobs
+  has_many :resumes
 
 
   def has_business?

--- a/app/views/resumes/_resume.html.erb
+++ b/app/views/resumes/_resume.html.erb
@@ -1,0 +1,10 @@
+<div class=" row " >
+  <div class='gh-job-details'>
+    <div class="gh-job-header">
+      <%= link_to resume.title, resume %>
+    </div>
+  </div>
+
+  <div class="button">
+  </div>
+</div>

--- a/app/views/resumes/new.html.erb
+++ b/app/views/resumes/new.html.erb
@@ -1,0 +1,22 @@
+<% content_for :navbar_links do %>
+  <%= render 'layouts/basic_navbar/user_links' %>
+<% end %>
+
+<%= render "layouts/page_heading", locals = {heading: "New Resume: #{current_user.nickname}"}%>
+
+<div class="container-fluid page-content">
+<div class="row">
+  <div class="col-md-9 col-centered ">
+    <div class="panel-body gh-main-content">
+      <%= bootstrap_form_for @resume do |f| %>
+        <%= f.text_field :title, placeholder: "Title" %>
+        <% @repositories.each do |repository| %>
+          <%= check_box_tag "resume[repository_ids][]", repository.id, f.object.repositories.include?(repository) %>
+          <%= repository.name %>
+        <% end %>
+        <%= f.submit "Create Job", class: "gh-form-button col-centered col-md-4 btn btn-primary" %>
+      <% end %>
+  </div>
+  </div>
+</div>
+</div>

--- a/app/views/resumes/new.html.erb
+++ b/app/views/resumes/new.html.erb
@@ -9,10 +9,11 @@
   <div class="col-md-9 col-centered ">
     <div class="panel-body gh-main-content">
       <%= bootstrap_form_for @resume do |f| %>
-        <%= f.text_field :title, placeholder: "Title" %>
+        <%= f.text_field :title, placeholder: "Ruby Developer, Javascript Ninja, PHP Wizard" %>
         <% @repositories.each do |repository| %>
-          <%= check_box_tag "resume[repository_names][]", repository %>
-          <%= repository %>
+          <%= check_box_tag "resume[repository_ids][]", repository.id, f.object.repositories.include?(repository)  %>
+          <%= repository.full_name %>
+          </br>
         <% end %>
         <%= f.submit "Create Job", class: "gh-form-button col-centered col-md-4 btn btn-primary" %>
       <% end %>

--- a/app/views/resumes/new.html.erb
+++ b/app/views/resumes/new.html.erb
@@ -11,8 +11,8 @@
       <%= bootstrap_form_for @resume do |f| %>
         <%= f.text_field :title, placeholder: "Title" %>
         <% @repositories.each do |repository| %>
-          <%= check_box_tag "resume[repository_ids][]", repository.id, f.object.repositories.include?(repository) %>
-          <%= repository.name %>
+          <%= check_box_tag "resume[repository_names][]", repository %>
+          <%= repository %>
         <% end %>
         <%= f.submit "Create Job", class: "gh-form-button col-centered col-md-4 btn btn-primary" %>
       <% end %>

--- a/app/views/resumes/show.html.erb
+++ b/app/views/resumes/show.html.erb
@@ -1,0 +1,26 @@
+<% content_for :navbar_links do %>
+<%= render 'layouts/basic_navbar/user_links' %>
+<% end %>
+
+<%= render "layouts/page_heading", locals = {heading: link_to(@resume.user.nickname, profile_path) }%>
+
+<div>
+  <div class="container">
+
+    <div class="row">
+      <h1><%= @resume.title %></h1>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        <h3>Repositories:</h3>
+      </div>
+    </div>
+    <div class="benefits row">
+        <% @repositories.each do |repository| %>
+          <div class="col-md-10 col-centered">
+            <%= link_to repository.name, "http://github.com/#{repository.full_name}" %>
+          </div>
+        <% end %>
+    </div>
+    <hr><br>
+  </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,7 +35,7 @@
         <div class="row">
           <div class="col-md-12">
             <div class="joblist">
-               <%= render partial: "/jobs/job", collection: @jobs, locals: {type: "feed" } %>
+               <%= render partial: "/jobs/job", collection: @jobs, locals: { type: "feed" } %>
             </div>
           </div>
         </div>
@@ -43,7 +43,7 @@
           <div class="col-md-12">
             <div class="watchlist">
               <h3>Watched: </h3>
-              <%= render partial: "/jobs/job", collection: @watchlist, locals: {type: "watchlist" } %>
+              <%= render partial: "/jobs/job", collection: @watchlist, locals: { type: "watchlist" } %>
             </div>
           </div>
         </div>
@@ -51,7 +51,13 @@
     </div>
     <div class="col-md-3">
       <div class="panel-body">
-        <h3>RESUMES</h3>
+        <h3>MY RESUMES</h3>
+        <%= link_to "Create New Resume", new_resume_path, class: "btn btn-md
+        btn-primary" %>
+        </br>
+        </br>
+        <%= render partial: "/resumes/resume", collection: @resumes, locals: { type:
+          "profile" } %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   put "/profile", to: "users#update"
   resources :jobs, only: [:new, :show, :index]
   get "/jobs", to: "jobs#index"
-  resources :resumes, only: [:new, :create]
+  resources :resumes, only: [:new, :create, :show]
 
   get "/contact", to: "home#contact"
   get "/about", to: "home#about"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   put "/profile", to: "users#update"
   resources :jobs, only: [:new, :show, :index]
   get "/jobs", to: "jobs#index"
+  resources :resumes, only: [:new, :create]
 
   get "/contact", to: "home#contact"
   get "/about", to: "home#about"

--- a/db/migrate/20151021003549_create_repository.rb
+++ b/db/migrate/20151021003549_create_repository.rb
@@ -1,0 +1,8 @@
+class CreateRepository < ActiveRecord::Migration
+  def change
+    create_table :repositories do |t|
+      t.string :full_name
+      t.string :name
+    end
+  end
+end

--- a/db/migrate/20151021004212_create_resumes.rb
+++ b/db/migrate/20151021004212_create_resumes.rb
@@ -1,0 +1,8 @@
+class CreateResumes < ActiveRecord::Migration
+  def change
+    create_table :resumes do |t|
+      t.integer :user_id
+      t.string :title
+    end
+  end
+end

--- a/db/migrate/20151021022125_create_resume_repositories.rb
+++ b/db/migrate/20151021022125_create_resume_repositories.rb
@@ -1,0 +1,8 @@
+class CreateResumeRepositories < ActiveRecord::Migration
+  def change
+    create_table :resume_repositories do |t|
+      t.integer :resume_id
+      t.integer :repository_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151020185322) do
+ActiveRecord::Schema.define(version: 20151021022125) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,21 @@ ActiveRecord::Schema.define(version: 20151020185322) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "status",     default: 0
+  end
+
+  create_table "repositories", force: :cascade do |t|
+    t.string "full_name"
+    t.string "name"
+  end
+
+  create_table "resume_repositories", force: :cascade do |t|
+    t.integer "resume_id"
+    t.integer "repository_id"
+  end
+
+  create_table "resumes", force: :cascade do |t|
+    t.integer "user_id"
+    t.string  "title"
   end
 
   create_table "tag_names", force: :cascade do |t|

--- a/spec/features/user_has_resumes_spec.rb
+++ b/spec/features/user_has_resumes_spec.rb
@@ -3,17 +3,21 @@ require "rails_helper"
 RSpec.feature "User has resumes" do
   context "to choose from" do
     xscenario "after creating them" do
-      @user = create(:user)
-      session[:user_id] = @user.id
+      login_with_oauth
 
       visit profile_path
       click_on("Create New Resume")
-      fill_in("Title", with: "Ruby Programmer")
+      fill_in("Title", with: "Ruby Developer")
       select("Repo1", from: "Repositories")
+      fill_in("Additional Information", with: "My first project")
       click_on("Create Resume")
 
       expect(current_path).to eq(profile_path)
       expect(page).to have_content("Ruby Programmer")
+
+      click_on("Ruby Programmer")
+      expect(current_path).to eq(resume_path(Resume.last))
+      expect(page).to have_content("My first project")
     end
   end
 end

--- a/spec/features/user_has_resumes_spec.rb
+++ b/spec/features/user_has_resumes_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "User has resumes" do
       click_on("Create New Resume")
       fill_in("Title", with: "Ruby Developer")
       select("Repo1", from: "Repositories")
-      fill_in("Additional Information", with: "My first project")
+      fill_in("Repo1 Additional Information", with: "My first project")
       click_on("Create Resume")
 
       expect(current_path).to eq(profile_path)


### PR DESCRIPTION
This pr creates a basic implementation of a user creating resumes directly from the Github api.

The user clicks new resume and it is populated with a listing of their repositories.

They can then pick the ones they want to send along as well as a title.

In order to do this two additional tables were created (resumes and repositories) and they are connected by a many to many relationship.
